### PR TITLE
Added Try/Except To Catch Single Frame Failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,9 +57,11 @@ class Application:
 
             att_img = self.data_manager.get()
 
-            output = self.model(att_img)
-
-            self.data_manager.save(output)
+            try:
+                output = self.model(att_img)
+                self.data_manager.save(output)
+            except:
+                print("skipped frame")
 
 
 @hydra.main(config_path="configs/", config_name="run_image.yaml")


### PR DESCRIPTION
I was having a problem where sometimes the face swapping would fail on a single frame and terminate the whole video (similar to https://github.com/mike9251/simswap-inference-pytorch/issues/2). I added a try/except to keep execution rolling when these edge cases happen.

Thought it might be useful to everyone else :)